### PR TITLE
feat: support relationships via links

### DIFF
--- a/diagrams/components/shared/setup.ftl
+++ b/diagrams/components/shared/setup.ftl
@@ -35,6 +35,13 @@
             resourceProvider=provider
             resourceType=componentResourceType
         /]
+
+        [#if ((solution.Links)!{})?has_content ]
+            [@addDiagramRelationshipsFromLinks
+                occurrence=occurrence
+                links=getLinkTargets(occurrence)
+            /]
+        [/#if]
     [/#if]
 
     [#list occurrence.Occurrences![] as subOccurrence]
@@ -59,6 +66,14 @@
                 resourceProvider=provider
                 resourceType=componentResourceType
             /]
+
+            [#if ((subSolution.Links)!{})?has_content ]
+                [@addDiagramRelationshipsFromLinks
+                    occurrence=subOccurrence
+                    links=getLinkTargets(subOccurrence)
+                /]
+            [/#if]
+
         [/#if]
     [/#list]
 [/#macro]

--- a/diagrams/deploymentframeworks/exec/output.ftl
+++ b/diagrams/deploymentframeworks/exec/output.ftl
@@ -1,10 +1,10 @@
 [#ftl]
 
-[@initialiseJsonOutput name="entities" /]
-[@initialiseJsonOutput name="groups" /]
-[@initialiseJsonOutput name="relationships" /]
-
 [#macro exec_output_json level="" include=""]
+    [@initialiseJsonOutput name="entities" /]
+    [@initialiseJsonOutput name="groups" /]
+    [@initialiseJsonOutput name="relationships" /]
+
     [#-- Resources --]
     [#if include?has_content]
         [#include include?ensure_starts_with("/")]

--- a/diagrams/deploymentframeworks/exec/output.ftl
+++ b/diagrams/deploymentframeworks/exec/output.ftl
@@ -16,23 +16,20 @@
         /]
     [/#if]
 
-    [#if getOutputContent("entities")?has_content || logMessages?has_content ]
-
-        [@toJSON
-            {
-                "Metadata" : {
-                    "Id" : getOutputContent("contract"),
-                    "Prepared" : .now?iso_utc,
-                    "RunId" : commandLineOptions.Run.Id,
-                    "RequestReference" : commandLineOptions.References.Request,
-                    "ConfigurationReference" : commandLineOptions.References.Configuration
-                },
-                "entities" : (getOutputContent("entities")?values)?sort_by("entityID")
-            } +
-            attributeIfContent("relationships", getOutputContent("relationships")?values) +
-            attributeIfContent("groups", (getOutputContent("groups")?values)?sort_by("groupID")) +
-            attributeIfContent("COTMessages", logMessages)
-        /]
-    [/#if]
+    [@toJSON
+        {
+            "Metadata" : {
+                "Id" : getOutputContent("contract"),
+                "Prepared" : .now?iso_utc,
+                "RunId" : commandLineOptions.Run.Id,
+                "RequestReference" : commandLineOptions.References.Request,
+                "ConfigurationReference" : commandLineOptions.References.Configuration
+            },
+            "entities" : (getOutputContent("entities")?values)?sort_by("entityID")
+        } +
+        attributeIfContent("relationships", getOutputContent("relationships")?values) +
+        attributeIfContent("groups", (getOutputContent("groups")?values)?sort_by("groupID")) +
+        attributeIfContent("COTMessages", logMessages)
+    /]
     [@serialiseOutput name=JSON_DEFAULT_OUTPUT_TYPE /]
 [/#macro]

--- a/diagrams/services/group/resource.ftl
+++ b/diagrams/services/group/resource.ftl
@@ -5,12 +5,9 @@
         name="groups"
         content={
             id : {
-                "groupID" : id
-            } +
-            attributeIfContent(
-                "parentID",
-                parentId
-            )
+                "groupID" : id,
+                "parentID" : parentId
+            }
         }
     /]
 [/#macro]

--- a/diagrams/services/relationship/resource.ftl
+++ b/diagrams/services/relationship/resource.ftl
@@ -3,6 +3,22 @@
 [#assign ONEWAY_DIAGRAMS_RELATIONSHIP = "one way" ]
 [#assign TWOWAY_DIAGRAMS_RELATIONSHIP = "two way" ]
 
+[#macro addDiagramRelationshipsFromLinks occurrence links ]
+    [#list links as id, link ]
+        [#if (link.Direction)?lower_case == "inbound" ]
+            [#local direction = TWOWAY_DIAGRAMS_RELATIONSHIP ]
+        [#else]
+            [#local direction = ONEWAY_DIAGRAMS_RELATIONSHIP ]
+        [/#if]
+
+        [@execDiagramRelationship
+            startEntityId=occurrence.Core.Id
+            endIdentityId=link.Core.Id
+            direction=direction
+        /]
+    [/#list]
+[/#macro]
+
 [#macro execDiagramRelationship startEntityId endIdentityId direction ]
     [@mergeWithJsonOutput
         name="relationships"


### PR DESCRIPTION
## Description

Adds relationships based on a components links, defined at the root of the component configuration 

## Context 

We follow a reasonably standard location for defining links across our components, this uses this location in the component configuration to provide a default set of relationships between components 