### PR TITLE
feat: level based diagram types

### DIFF
--- a/diagrams/components/component.ftl
+++ b/diagrams/components/component.ftl
@@ -1,1 +1,13 @@
 [#ftl]
+
+[@addDiagramType
+    type="overview"
+    deploymentGroup="overview"
+    description="An overview of all components and their relationships with other components"
+/]
+
+[@addDiagramType
+    type="resources"
+    deploymentGroup="resources"
+    description="Shows all resources that are used in a segment and the deployment group they are used in"
+/]

--- a/diagrams/components/shared/setup.ftl
+++ b/diagrams/components/shared/setup.ftl
@@ -4,7 +4,7 @@
     [@addDefaultGenerationContract subsets=[ "config" ] /]
 [/#macro]
 
-[#macro shared_diagram_config occurrence ]
+[#macro shared_diagram_config_overview occurrence ]
 
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
@@ -31,7 +31,7 @@
         [@execDiagramEntity
             id=core.Id
             name=core.FullName
-            groupdId=core.Name
+            groupId=core.Name
             resourceProvider=provider
             resourceType=componentResourceType
         /]
@@ -62,7 +62,7 @@
             [@execDiagramEntity
                 id=subCore.Id
                 name=subCore.FullName
-                groupdId=subCore.Name
+                groupId=subCore.Name
                 resourceProvider=provider
                 resourceType=componentResourceType
             /]
@@ -75,5 +75,34 @@
             [/#if]
 
         [/#if]
+    [/#list]
+[/#macro]
+
+[#macro shared_diagram_config_resources occurrence ]
+
+    [#local solution = occurrence.Configuration.Solution ]
+    [#local defaultDeploymentGroup = solution["deployment:Group"]!""]
+
+    [#local allOccurrences = asFlattenedArray( [ occurrence, occurrence.Occurrences![] ], true )]
+    [#list allOccurrences as occurrence ]
+        [#local resources = occurrence.State.Resources ]
+        [#local solution = occurrence.Configuration.Solution]
+
+        [#local placement = (occurrence.State.ResourceGroups["default"].Placement)!{} ]
+        [#local provider = placement.Provider!commandLineOptions.Deployment.Provider.Names[0] ]
+
+        [#local deploymentGroup = solution["deployment:Group"]!defaultDeploymentGroup ]
+
+        [@execDiagramGroup
+            id=deploymentGroup
+            parentId=""
+        /]
+
+        [@addDiagramEntitiesFromResources
+            resources=resources!{}
+            groupId=deploymentGroup
+            provider=provider
+        /]
+
     [/#list]
 [/#macro]

--- a/diagrams/entrances/diagram/entrance.ftl
+++ b/diagrams/entrances/diagram/entrance.ftl
@@ -2,7 +2,26 @@
 
 [#macro diagrams_entrance_diagram ]
 
+
+  [#if (commandLineOptions.Deployment.Unit.Subset!"") == "generationcontract" ]
+    [@setupContractOutputs /]
+    [#assign allDeploymentUnits = false]
+  [/#if]
+
   [#assign allDeploymentUnits = true]
+
+  [#local diagramType = commandLineOptions.Deployment.Group.Name]
+  [#local diagramTypeDetails = getDiagramType(diagramType)]
+
+  [#if ! diagramTypeDetails?has_content ]
+    [@fatal
+      message="Invalid Diagram Type"
+      detail="Please provide an available diagram type using the deploymentGroup/level"
+      context={
+        "DeploymentGroup" : commandLineOptions.Deployment.Group.Name
+      }
+    /]
+  [/#if]
 
   [#-- override the deployment group to get all deployment groups --]
   [@addCommandLineOption
@@ -21,10 +40,6 @@
       }
   /]
 
-  [#if (commandLineOptions.Deployment.Unit.Subset!"") == "generationcontract" ]
-    [#assign allDeploymentUnits = false]
-  [/#if]
-
   [#-- Preload the configuration as it won't be avaiable via the other providers --]
   [@includeProviderComponentConfiguration
     provider=DIAGRAMS_PROVIDER
@@ -41,6 +56,7 @@
       deploymentFramework=DIAGRAMS_EXEC_DEPLOYMENT_FRAMEWORK
       type=commandLineOptions.Deployment.Output.Type
       format=commandLineOptions.Deployment.Output.Format
+      level=diagramTypeDetails.DeploymentGroup!""
   /]
 
 [/#macro]

--- a/diagrams/entrances/diagraminfo/entrance.ftl
+++ b/diagrams/entrances/diagraminfo/entrance.ftl
@@ -1,0 +1,35 @@
+[#ftl]
+
+[#macro diagrams_entrance_diagraminfo ]
+
+  [#-- override the deployment group to get all deployment groups --]
+  [@addCommandLineOption
+      option={
+        "Deployment" : {
+          "Framework" : {
+            "Name" : DIAGRAMS_EXEC_DEPLOYMENT_FRAMEWORK
+          },
+          "Provider" : {
+            "Names" : combineEntities(
+                        [ "diagrams" ],
+                        commandLineOptions.Deployment.Provider.Names,
+                        UNIQUE_COMBINE_BEHAVIOUR
+                      )
+          }
+        },
+        "View" : {
+          "Name" : DIAGRAMINFO_VIEW_TYPE
+        },
+        "Flow" : {
+          "Names" : [ "views" ]
+        }
+      }
+  /]
+
+  [@generateOutput
+    deploymentFramework=commandLineOptions.Deployment.Framework.Name
+    type=commandLineOptions.Deployment.Output.Type
+    format=commandLineOptions.Deployment.Output.Format
+  /]
+
+[/#macro]

--- a/diagrams/entrances/diagraminfo/id.ftl
+++ b/diagrams/entrances/diagraminfo/id.ftl
@@ -1,0 +1,18 @@
+[#ftl]
+
+[@addEntrance
+    type=DIAGRAMINFO_ENTRANCE_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "Provides a list of the available diagrams"
+            }
+        ]
+    commandlineoptions=[
+        {
+            "Names" : "*",
+            "Type" : ANY_TYPE
+        }
+    ]
+/]

--- a/diagrams/entrances/entrance.ftl
+++ b/diagrams/entrances/entrance.ftl
@@ -1,3 +1,4 @@
 [#ftl]
 
 [#assign DIAGRAM_ENTRANCE_TYPE = "diagram" ]
+[#assign DIAGRAMINFO_ENTRANCE_TYPE = "diagraminfo" ]

--- a/diagrams/provider.ftl
+++ b/diagrams/provider.ftl
@@ -1,5 +1,48 @@
 [#ftl]
 
 [#assign DIAGRAMS_PROVIDER = "diagrams"]
-
 [#assign DIAGRAMS_EXEC_DEPLOYMENT_FRAMEWORK = "exec" ]
+
+
+[#-- Diagram Types Configuration --]
+[#assign diagramTypes = {}]
+
+[#macro addDiagramType type deploymentGroup description name="" ]
+    [#local configuration =
+        {
+            "Name" : contentIfContent(name, type),
+            "Type" : type,
+            "Description" : description,
+            "DeploymentGroup" : deploymentGroup
+        }
+    ]
+
+    [@internalMergeDiagramTypesConfiguration
+        type=type
+        configuration=configuration
+    /]
+[/#macro]
+
+
+[#function getDiagramType type ]
+    [#return diagramTypes[type]!{} ]
+[/#function]
+
+[#function getAllDiagramTypes ]
+    [#return diagramTypes ]
+[/#function]
+
+[#-------------------------------------------------------
+-- Internal support functions for component processing --
+---------------------------------------------------------]
+
+[#-- Helper macro - not for general use --]
+[#macro internalMergeDiagramTypesConfiguration type configuration]
+    [#assign diagramTypes =
+        mergeObjects(
+            diagramTypes,
+            {
+                type : configuration
+            }
+        )]
+[/#macro]

--- a/diagrams/services/entity/resource.ftl
+++ b/diagrams/services/entity/resource.ftl
@@ -1,12 +1,45 @@
 [#ftl]
 
-[#macro execDiagramEntity id name groupdId resourceProvider resourceProvider resourceType ]
+[#macro addDiagramEntitiesFromResources resources groupId provider ]
+    [#list resources as id, resource]
+        [#if resource?is_hash && (resource.Type)?? ]
+            [@execDiagramEntity
+                id=formatId(groupId, resource.Type)
+                name=resource.Type
+                groupId=groupId
+                resourceProvider=provider
+                resourceType=resource.Type
+            /]
+            [#continue]
+        [/#if]
+
+        [#if resource?is_hash ]
+            [@addDiagramEntitiesFromResources
+                resources=resource
+                groupId=groupId
+                provider=provider
+            /]
+        [/#if]
+
+        [#if resource?is_sequence ]
+            [#list resource as groupResource ]
+                [@addDiagramEntitiesFromResources
+                    resources=groupResource
+                    groupId=groupId
+                    provider=provider
+                /]
+            [/#list]
+        [/#if]
+    [/#list]
+[/#macro]
+
+[#macro execDiagramEntity id name groupId resourceProvider resourceProvider resourceType ]
     [@mergeWithJsonOutput
         name="entities"
         content={
             id : {
                 "entityID" : id,
-                "groupID" : groupdId,
+                "groupID" : groupId,
                 "type" : getDiagramClass(resourceProvider, "*", resourceType),
                 "entityName" : name
             }

--- a/diagrams/views/diagraminfo/setup.ftl
+++ b/diagrams/views/diagraminfo/setup.ftl
@@ -1,0 +1,14 @@
+[#ftl]
+
+[#macro diagrams_view_diagraminfo_exec_generationcontract  ]
+    [@addDefaultGenerationContract subsets=[ "diagraminfo" ] /]
+[/#macro]
+
+[#macro diagrams_view_diagraminfo_exec ]
+    [#list getAllDiagramTypes() as type,details ]
+        [@diagramInfoDiagram
+            type=type
+            details=details
+        /]
+    [/#list]
+[/#macro]

--- a/diagrams/views/view.ftl
+++ b/diagrams/views/view.ftl
@@ -1,0 +1,3 @@
+[#ftl]
+
+[#assign DIAGRAMINFO_VIEW_TYPE = "diagraminfo" ]


### PR DESCRIPTION
Adds support for generating different diagrams as a dyanmically loaded
process

Using the deploymentGroup/Level different diagram setup routines can be
invoked to generate diagrams for different purposes

Also adds a diagraminfo flow/view to discover the diagrams that are
available