### PR TITLE
fix: default branch for packaging

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -3,7 +3,7 @@ name: package
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
 
@@ -26,7 +26,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push latest
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v2
         with:
           tags: "ghcr.io/${{ github.repository}}:latest"


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

Update the default branch for docker packaging to use main instead of master

## Motivation and Context

images not created as wrong branch used in trigger 

## How Has This Been Tested?

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

